### PR TITLE
Add EOS 7D Mark II

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -1310,6 +1310,7 @@ static struct {
 	{"Canon:EOS 5D Mark II",		0x04a9, 0x3199, PTP_CAP|PTP_CAP_PREVIEW|PTPBUG_DELETE_SENDS_EVENT},
 	/* Thomas Tanner <thomas@tannerlab.com> */
 	{"Canon:EOS 7D",			0x04a9, 0x319a, PTP_CAP|PTP_CAP_PREVIEW|PTPBUG_DELETE_SENDS_EVENT},
+	{"Canon:EOS 7D Mark II",                0x04a9, 0x326f, PTP_CAP|PTP_CAP_PREVIEW|PTPBUG_DELETE_SENDS_EVENT},
 	/* mitch <debianuser@mll.dissimulo.com> */
 	{"Canon:EOS 50D",			0x04a9, 0x319b, PTP_CAP|PTP_CAP_PREVIEW|PTPBUG_DELETE_SENDS_EVENT},
 


### PR DESCRIPTION
Add the USB ID for EOS 7D Mark II
