### PR TITLE
Update URL to Panasonic DC1000 open source driver code web page.

### DIFF
--- a/camlibs/panasonic/README.panasonic
+++ b/camlibs/panasonic/README.panasonic
@@ -72,7 +72,7 @@ References
 		
 	* dc1000 web page:
 	 
-	 	http://www.df.lth.se/~roubert/dc1000/
+	 	https://roubert.name/fredrik/dc1000/
 	 
 	* Panasonic DC1000 PalmCam communication protocol:
 	 	


### PR DESCRIPTION
The old webserver has been decommissioned.
